### PR TITLE
Fix power button page turn on long-press sleep

### DIFF
--- a/src/states/ReaderState.cpp
+++ b/src/states/ReaderState.cpp
@@ -248,6 +248,7 @@ void ReaderState::enter(Core& core) {
   loadFailed_ = false;
   needsRender_ = true;
   holdNavigated_ = false;
+  powerPressStartedMs_ = 0;
   stopBackgroundCaching();  // Ensure any previous task is stopped
   parser_.reset();          // Safe - task is stopped
   parserSpineIndex_ = -1;
@@ -458,7 +459,7 @@ StateTransition ReaderState::update(Core& core) {
             return StateTransition::stay(StateId::Reader);
           case Button::Power:
             if (core.settings.shortPwrBtn == Settings::PowerPageTurn) {
-              navigateNext(core);
+              powerPressStartedMs_ = millis();
             }
             break;
           default:
@@ -496,9 +497,20 @@ StateTransition ReaderState::update(Core& core) {
             case Button::Up:
               navigatePrev(core);
               break;
+            case Button::Power:
+              if (core.settings.shortPwrBtn == Settings::PowerPageTurn && powerPressStartedMs_ != 0) {
+                const uint32_t heldMs = millis() - powerPressStartedMs_;
+                if (heldMs < core.settings.getPowerButtonDuration()) {
+                  navigateNext(core);
+                }
+              }
+              break;
             default:
               break;
           }
+        }
+        if (e.button == Button::Power) {
+          powerPressStartedMs_ = 0;
         }
         holdNavigated_ = false;
         break;
@@ -1396,7 +1408,7 @@ void ReaderState::exitTocMode() {
 }
 
 void ReaderState::handleTocInput(Core& core, const Event& e) {
-  if (e.type != EventType::ButtonPress && e.type != EventType::ButtonRepeat) {
+  if (e.type != EventType::ButtonPress && e.type != EventType::ButtonRepeat && e.type != EventType::ButtonRelease) {
     return;
   }
 
@@ -1434,8 +1446,16 @@ void ReaderState::handleTocInput(Core& core, const Event& e) {
 
     case Button::Power:
       if (core.settings.shortPwrBtn == Settings::PowerPageTurn) {
-        tocView_.moveDown();
-        needsRender_ = true;
+        if (e.type == EventType::ButtonPress) {
+          powerPressStartedMs_ = millis();
+        } else if (e.type == EventType::ButtonRelease && powerPressStartedMs_ != 0) {
+          const uint32_t heldMs = millis() - powerPressStartedMs_;
+          if (heldMs < core.settings.getPowerButtonDuration()) {
+            tocView_.moveDown();
+            needsRender_ = true;
+          }
+          powerPressStartedMs_ = 0;
+        }
       }
       break;
   }

--- a/src/states/ReaderState.h
+++ b/src/states/ReaderState.h
@@ -100,6 +100,11 @@ class ReaderState : public State {
   // Track whether a chapter jump already fired during a button hold
   bool holdNavigated_ = false;
 
+  // Track power press start when short power action is mapped to page turn.
+  // This lets us execute page turn only on short release and avoid accidental
+  // turns when the same press is held to enter sleep.
+  uint32_t powerPressStartedMs_ = 0;
+
   // Rendering
   void renderCurrentPage(Core& core);
   void renderCachedPage(Core& core);


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** 
Fix a small UX issue: when short power-button press is configured as page turn, putting the device to sleep via long press should not also turn a page.
* **What changes are included?**
ReaderState now tracks how long the power button is held when short-press page turn is enabled.
Page turn is deferred until release and only triggered for true short presses; long presses are treated as sleep action only.
## Additional Context

* Add any other information that might be helpful for the reviewer (e.g., performance implications, potential risks, specific areas to focus on).
