### PR TITLE
Fix text loss at page boundaries during incremental parsing

### DIFF
--- a/lib/Epub/src/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/src/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -697,7 +697,7 @@ bool ChapterHtmlSlimParser::parseLoop() {
       currentTextBlock->setUseGreedyBreaking(true);
       currentTextBlock->layoutAndExtractLines(
           renderer, config.fontId, config.viewportWidth,
-          [this](const std::shared_ptr<TextBlock>& textBlock) { addLineToPage(textBlock); }, false,
+          [this](const std::shared_ptr<TextBlock>& textBlock) { addLineToPage(textBlock); }, true,
           [this]() -> bool { return stopRequested_ || shouldAbort(); });
     }
   } while (!done);

--- a/lib/Fb2/src/Fb2Parser.cpp
+++ b/lib/Fb2/src/Fb2Parser.cpp
@@ -376,7 +376,9 @@ void Fb2Parser::makePages() {
                                              if (hitMaxPages_) {
                                                continueProcessing = false;
                                              }
-                                           });
+                                           },
+                                           true,
+                                           [&continueProcessing]() -> bool { return !continueProcessing; });
 
   // Paragraph spacing (same pattern as PlainTextParser/ChapterHtmlSlimParser)
   if (!hitMaxPages_) {
@@ -388,9 +390,9 @@ void Fb2Parser::makePages() {
         currentPageNextY_ += lineHeight;
         break;
     }
+    currentTextBlock_.reset();
   }
-
-  currentTextBlock_.reset();
+  // else: currentTextBlock_ still has unconsumed words — preserve for next batch
 }
 
 void Fb2Parser::addLineToPage(std::shared_ptr<TextBlock> line) {

--- a/lib/Markdown/src/MarkdownParser.cpp
+++ b/lib/Markdown/src/MarkdownParser.cpp
@@ -38,6 +38,7 @@ void MarkdownParser::reset() {
   currentOffset_ = 0;
   hasMore_ = true;
   isRtl_ = false;
+  pendingTextBlock_.reset();
 }
 
 int MarkdownParser::getCurrentFontStyle(const ParseContext& ctx) const {
@@ -92,9 +93,14 @@ void MarkdownParser::flushTextBlock(ParseContext& ctx) {
                                          if (!ctx.hitMaxPages) {
                                            addLineToPage(ctx, textBlock);
                                          }
-                                       });
+                                       },
+                                       true,
+                                       [&ctx]() -> bool { return ctx.hitMaxPages; });
 
-  ctx.textBlock.reset();
+  if (!ctx.hitMaxPages) {
+    ctx.textBlock.reset();
+  }
+  // else: textBlock still has unconsumed words — preserve for next batch
 
   switch (config_.spacingLevel) {
     case 1:
@@ -370,6 +376,22 @@ bool MarkdownParser::parsePages(const std::function<void(std::unique_ptr<Page>)>
   md_parser_t parser;
   md_parser_init(&parser, tokenCallback, &ctx);
 
+  // Resume: flush any pending text block carried over from a previous interrupted batch
+  if (pendingTextBlock_) {
+    ctx.textBlock = std::move(pendingTextBlock_);
+    flushTextBlock(ctx);
+    if (ctx.hitMaxPages) {
+      // Still can't fit — save and return
+      pendingTextBlock_ = std::move(ctx.textBlock);
+      if (ctx.currentPage && !ctx.currentPage->elements.empty() && onPageComplete) {
+        onPageComplete(std::move(ctx.currentPage));
+        ctx.pagesCreated++;
+      }
+      file.close();
+      return true;
+    }
+  }
+
   // Start with a paragraph block
   startNewTextBlock(ctx, config_.paragraphAlignment);
 
@@ -430,7 +452,8 @@ bool MarkdownParser::parsePages(const std::function<void(std::unique_ptr<Page>)>
                 addLineToPage(ctx, textBlock);
               }
             },
-            false);
+            false,
+            [&ctx]() -> bool { return ctx.hitMaxPages; });
       }
     }
   }
@@ -442,6 +465,13 @@ bool MarkdownParser::parsePages(const std::function<void(std::unique_ptr<Page>)>
   if (ctx.currentPage && !ctx.currentPage->elements.empty() && onPageComplete) {
     onPageComplete(std::move(ctx.currentPage));
     ctx.pagesCreated++;
+  }
+
+  // Save any unconsumed text block for the next parsePages call
+  if (ctx.hitMaxPages && ctx.textBlock && !ctx.textBlock->isEmpty()) {
+    pendingTextBlock_ = std::move(ctx.textBlock);
+  } else {
+    pendingTextBlock_.reset();
   }
 
   currentOffset_ += bytesProcessed;

--- a/lib/Markdown/src/MarkdownParser.h
+++ b/lib/Markdown/src/MarkdownParser.h
@@ -56,6 +56,10 @@ class MarkdownParser : public ContentParser {
   // Line buffer for reading from file
   char lineBuffer_[LINE_BUFFER_SIZE];
 
+  // Carries over unconsumed words from a text block that was
+  // interrupted by a page-batch limit.
+  std::unique_ptr<ParsedText> pendingTextBlock_;
+
   // Parsing context passed through md_parser callback
   struct ParseContext {
     MarkdownParser* self;

--- a/lib/PageCache/src/PlainTextParser.cpp
+++ b/lib/PageCache/src/PlainTextParser.cpp
@@ -24,6 +24,7 @@ void PlainTextParser::reset() {
   currentOffset_ = 0;
   hasMore_ = true;
   isRtl_ = false;
+  pendingBlock_.reset();
 }
 
 bool PlainTextParser::parsePages(const std::function<void(std::unique_ptr<Page>)>& onPageComplete, uint16_t maxPages,
@@ -85,9 +86,14 @@ bool PlainTextParser::parsePages(const std::function<void(std::unique_ptr<Page>)
                                           if (!addLineToPage(line)) {
                                             continueProcessing = false;
                                           }
-                                        });
+                                        },
+                                        true,
+                                        [&]() -> bool { return !continueProcessing; });
 
-    currentBlock.reset();
+    if (continueProcessing) {
+      currentBlock.reset();
+    }
+    // else: currentBlock still has unconsumed words — preserve it
     return continueProcessing;
   };
 
@@ -101,8 +107,25 @@ bool PlainTextParser::parsePages(const std::function<void(std::unique_ptr<Page>)
   }
 
   startNewPage();
-  currentBlock.reset(new ParsedText(static_cast<TextBlock::BLOCK_STYLE>(config_.paragraphAlignment),
-                                    config_.indentLevel, config_.hyphenation, true, isRtl_));
+
+  // Resume: flush any pending block carried over from a previous interrupted batch
+  if (pendingBlock_) {
+    currentBlock = std::move(pendingBlock_);
+    if (!flushBlock()) {
+      // Still can't fit — save pending block and return
+      pendingBlock_ = std::move(currentBlock);
+      if (currentPage && !currentPage->elements.empty()) {
+        onPageComplete(std::move(currentPage));
+      }
+      file.close();
+      return true;
+    }
+  }
+
+  if (!currentBlock) {
+    currentBlock.reset(new ParsedText(static_cast<TextBlock::BLOCK_STYLE>(config_.paragraphAlignment),
+                                      config_.indentLevel, config_.hyphenation, true, isRtl_));
+  }
 
   while (file.available() > 0) {
     // Check for abort every few iterations
@@ -133,6 +156,8 @@ bool PlainTextParser::parsePages(const std::function<void(std::unique_ptr<Page>)
 
         // Flush current block (paragraph)
         if (!flushBlock()) {
+          // currentBlock still has unconsumed words — save for next call
+          pendingBlock_ = std::move(currentBlock);
           currentOffset_ = file.position() - (bytesRead - i - 1);
           hasMore_ = true;
           file.close();

--- a/lib/PageCache/src/PlainTextParser.h
+++ b/lib/PageCache/src/PlainTextParser.h
@@ -9,6 +9,7 @@
 #include "ContentParser.h"
 
 class GfxRenderer;
+class ParsedText;
 
 /**
  * Content parser for plain text files (TXT, Markdown).
@@ -22,6 +23,10 @@ class PlainTextParser : public ContentParser {
   size_t currentOffset_ = 0;
   bool hasMore_ = true;
   bool isRtl_ = false;
+
+  // Carries over unconsumed words from a paragraph that was
+  // interrupted by a page-batch limit.
+  std::unique_ptr<ParsedText> pendingBlock_;
 
  public:
   PlainTextParser(std::string filepath, GfxRenderer& renderer, const RenderConfig& config);


### PR DESCRIPTION
## Summary

All format parsers (TXT, Markdown, EPUB, FB2) silently drop text when a paragraph spans a page-batch boundary during incremental parsing (hot extend). This manifests as missing sentences/paragraphs when reading — the user turns the page and text that should follow is gone.

## Root Cause

When `layoutAndExtractLines()` is called and the page batch limit (`maxPages`) is reached mid-paragraph:

1. The `processLine` callback stops adding lines to pages (returns or sets a flag)
2. But the extract loop **continues** — `extractLine()` destructively erases words from the `ParsedText` object
3. After `flushBlock` returns false, the `ParsedText` is destroyed/reset — remaining words are **permanently lost**
4. The next `parsePages` call resumes from a saved file offset that is **past the lost text**

This affects every parser because they all share the same pattern of calling `layoutAndExtractLines()` without an abort callback to stop word consumption when the page limit is hit.

## The Fix

**Part 1 — Stop consuming words when the page limit is hit:**

Pass an abort callback to `layoutAndExtractLines()` that returns `true` when the page batch limit is reached. The existing abort check at `ParsedText.cpp:286-287` already handles this correctly — it returns `false` without consuming more words. The problem was that no caller was passing this callback.

**Part 2 — Preserve unconsumed words for the next batch:**

When the page limit interrupts a paragraph mid-layout, the `ParsedText` object still contains the remaining words. Instead of destroying it, save it as a class member (`pendingBlock_` / `pendingTextBlock_`) and flush it at the start of the next `parsePages` call.

## Parsers Fixed

| Parser | Changes |
|--------|---------|
| **PlainTextParser** | Added `pendingBlock_` member, abort callback in `flushBlock`, resume logic |
| **MarkdownParser** | Added `pendingTextBlock_` member, abort callback in `flushTextBlock` and memory-flush path |
| **Fb2Parser** | Added abort callback, conditional `currentTextBlock_` reset |
| **ChapterHtmlSlimParser** | Changed `includeLastLine` from `false` to `true` in emergency split (abort callback was already passed) |

## Test plan

- [x] Built and flashed on Xteink X4 (ESP32-C3)
- [x] Tested with long Arabic RTL markdown files that previously exhibited missing text between pages
- [x] Verified text flows correctly across all page boundaries after clearing page cache
- [ ] Test with EPUB and FB2 Arabic content
- [ ] Test with LTR content to verify no regression
- [ ] Test under memory pressure (large files on device with limited free heap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)