### PR TITLE
XtcPageRenderer: fix ghosting when changing between two images

### DIFF
--- a/src/rendering/XtcPageRenderer.cpp
+++ b/src/rendering/XtcPageRenderer.cpp
@@ -120,9 +120,6 @@ XtcPageRenderer::RenderResult XtcPageRenderer::render(xtc::XtcParser& parser, ui
   renderer_.clearScreen();
 
   if (bitDepth == 2) {
-    render2BitGrayscale(plane1Buffer, plane2Buffer, pageWidth, pageHeight);
-    refreshCallback();
-
     // Grayscale rendering requires additional passes
     const uint8_t* plane1 = plane1Buffer;
     const uint8_t* plane2 = plane2Buffer;
@@ -137,6 +134,17 @@ XtcPageRenderer::RenderResult XtcPageRenderer::render(xtc::XtcParser& parser, ui
       const uint8_t bit2 = (plane2[byteOffset] >> bitInByte) & 1;
       return (bit1 << 1) | bit2;
     };
+
+    // Pass 1: Black-and-white rendering
+    for (uint16_t y = 0; y < pageHeight; y++) {
+      for (uint16_t x = 0; x < pageWidth; x++) {
+        if (getPixelValue(x, y) >= 1) {
+          renderer_.drawPixel(x, y, true);
+        }
+      }
+      if (y % 100 == 0) esp_task_wdt_reset();
+    }
+    renderer_.displayBuffer(EInkDisplay::HALF_REFRESH);
 
     // Pass 2: LSB buffer - mark DARK gray (value 1)
     renderer_.clearScreen(0x00);
@@ -219,35 +227,6 @@ void XtcPageRenderer::render1Bit(const uint8_t* buffer, uint16_t width, uint16_t
         if (!((byte >> bit) & 1)) {  // XTC: 0 = black, 1 = white
           renderer_.drawPixel(x, srcY, true);
         }
-      }
-    }
-  }
-}
-
-void XtcPageRenderer::render2BitGrayscale(const uint8_t* plane1, const uint8_t* plane2, uint16_t width,
-                                          uint16_t height) {
-  // XTCH 2-bit mode: Two bit planes, column-major order
-  // - Columns scanned right to left (x = width-1 down to 0)
-  // - 8 vertical pixels per byte (MSB = topmost pixel in group)
-  // - First plane: Bit1, Second plane: Bit2
-  // - Pixel value = (bit1 << 1) | bit2
-  // - Grayscale: 0=White, 1=Dark Grey, 2=Light Grey, 3=Black
-
-  const size_t colBytes = (height + 7) / 8;
-
-  // Pass 1: BW buffer - draw all non-white pixels as black
-  for (uint16_t y = 0; y < height; y++) {
-    for (uint16_t x = 0; x < width; x++) {
-      const size_t colIndex = width - 1 - x;
-      const size_t byteInCol = y / 8;
-      const size_t bitInByte = 7 - (y % 8);
-      const size_t byteOffset = colIndex * colBytes + byteInCol;
-      const uint8_t bit1 = (plane1[byteOffset] >> bitInByte) & 1;
-      const uint8_t bit2 = (plane2[byteOffset] >> bitInByte) & 1;
-      const uint8_t pixelValue = (bit1 << 1) | bit2;
-
-      if (pixelValue >= 1) {
-        renderer_.drawPixel(x, y, true);
       }
     }
   }

--- a/src/states/ReaderState.cpp
+++ b/src/states/ReaderState.cpp
@@ -1796,9 +1796,6 @@ void ReaderState::renderXtcPage(Core& core) {
 
   switch (result) {
     case XtcPageRenderer::RenderResult::Success:
-      if (provider->getParser().getBitDepth() == 2) {
-        pagesUntilFullRefresh_ = 1;
-      }
       break;
     case XtcPageRenderer::RenderResult::EndOfBook:
       ui::centeredMessage(renderer_, theme, theme.uiFontId, tr(END_OF_BOOK));


### PR DESCRIPTION
Hi,

2-bit grayscale XTCH files cause ghosting when flipping between pages with current v1.26.0 code.
Patch here fixes that.

I think issue is probably due to a bug in refreshCallback() being called with FAST_REFRESH, as `pagesUntilFullRefresh_ = 1;` is done after that callback is already called, and then that value is reset again, or something like that.

Either way, don't think 2-bit rendering path in XtcPageRenderer::render should ever rely on that callback having correct setting, as it should always do HALF refresh, and never do FAST one, unless ghosting is intended behavior, or there's some other way to fix it with FAST_REFRESH.

This commit also removes large XtcPageRenderer::render2BitGrayscale routine that duplicates subsequent steps in that rendering path, doing what it does with a simpler loop, same as in other 2-bit rendering steps right after.

Zip file with ghost.xtch easily demonstrating the problem, as well as BMP images used to assemble it (in case maybe it's some unlikely issue with XTCH file format there): [ghost-xtch-example.zip](https://github.com/user-attachments/files/30156709/ghost-xtch-example.zip)

Thanks.