### PR TITLE
ImageViewer: fix 2-bit grayscale rendering

### DIFF
--- a/src/apps/ImageViewerApp.cpp
+++ b/src/apps/ImageViewerApp.cpp
@@ -209,9 +209,12 @@ static bool renderImage() {
 
   ui::ButtonBar buttons("Back", "Menu", "<", ">");
   ui::buttonBar(renderer, theme, buttons);
-  renderer.displayBuffer();
 
-  if (bitmap.hasGreyscale()) {
+  if (!bitmap.hasGreyscale()) {
+    renderer.displayBuffer();
+  } else {
+    renderer.displayBuffer(EInkDisplay::HALF_REFRESH);
+
     bitmap.rewindToData();
     renderer.clearScreen(0x00);
     renderer.setRenderMode(GfxRenderer::GRAYSCALE_LSB);


### PR DESCRIPTION
Fixes earlier 6d29b78 commit that did not address the issue properly.
See https://github.com/bigbag/papyrix-reader/issues/149#issuecomment-5012433958 for more details.
